### PR TITLE
Allow writing tap output to console

### DIFF
--- a/tasks/qunit-tap.js
+++ b/tasks/qunit-tap.js
@@ -11,7 +11,8 @@ module.exports = function(grunt) {
 	grunt.registerTask('qunit-tap', 'Run QUnit tasks with TAP reporting', function(){
 		var target = null,
 			data = {
-				output: ''
+				output: '',
+				outputConsole: false
 			};
 
 		if (this.args.length) {
@@ -51,8 +52,13 @@ module.exports = function(grunt) {
 			tap.push('# pass ' + passed);
 			tap.push('# fail ' + failed);
 
-			var tapFile = data.output + currentTest.replace(/\//g, '-') +'.tap';
-			grunt.file.write(tapFile, tap.join('\n'));
+			if (data.output !== undefined) {
+				var tapFile = data.output + currentTest.replace(/\//g, '-') +'.tap';
+				grunt.file.write(tapFile, tap.join('\n'));
+			}
+			if (data.outputConsole === true) {
+				grunt.log.writeln(tap.join('\n'));
+			}
 		});
 	}
 


### PR DESCRIPTION
Sometimes tap output should be written to console. Specifically [testling-ci](https://ci.testling.com/guide/custom_libraries) requires this.
The proposed changes:
- allow omitting the `output` parameter in order to suppress writing to files
- allow an additional `outputConsole` parameter which writes the TAP output to console (defaults to false)
